### PR TITLE
Remove plutus-apps packages

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,13 +20,7 @@ index-state:
   , cardano-haskell-packages 2022-12-22T00:00:00Z
 
 packages: 
-  ../plutus-apps/freer-extras
-  ./.
-  ../plutus-apps/cardano-node-emulator
-  ../plutus-apps/plutus-ledger
-  ../plutus-apps/plutus-script-utils
-  ../plutus-apps/plutus-ledger-constraints
-        
+  ./.        
 
 -- We never, ever, want this.
 write-ghc-environment-files: never
@@ -199,3 +193,16 @@ source-repository-package
       libs/small-steps
       libs/small-steps-test
       libs/non-integral
+
+-- This is needed because we rely on an unreleased feature
+-- https://github.com/input-output-hk/cardano-ledger/pull/3111
+source-repository-package
+    type: git
+    location: https://github.com/IntersectMBO/plutus-apps
+    tag: v1.1.0
+    subdir:
+      freer-extras
+      cardano-node-emulator
+      plutus-ledger
+      plutus-script-utils
+      plutus-ledger-constraints

--- a/cabal.project
+++ b/cabal.project
@@ -194,8 +194,7 @@ source-repository-package
       libs/small-steps-test
       libs/non-integral
 
--- This is needed because we rely on an unreleased feature
--- https://github.com/input-output-hk/cardano-ledger/pull/3111
+-- This is needed because the packages are missing from CHaP at the specified index-state.
 source-repository-package
     type: git
     location: https://github.com/IntersectMBO/plutus-apps

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+let
+  plutus_apps = builtins.getFlake "github:IntersectMBO/plutus-apps?ref=v1.1.0";
+in
+import "${plutus_apps}/shell.nix"


### PR DESCRIPTION
Hey,

it looks like the `plutus-apps` packages don't need to be included in project. I moved them into `source-repository-package` dependency.

Also provided a `shell.nix` file - mostly to double check with you if that is the correct development shell for this repository?

If you like these changes we could agree to base the audit on top of this revision.